### PR TITLE
Fix pointer icon in projectorganizer

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -614,6 +614,9 @@ function _poResolveIcon(item) {
     if (item.data.isFolder) {
         return returnView('folder');
     }
+    if(item.data.isPointer && !item.parent().data.isFolder){
+        return returnView('link');
+    }
     if (item.data.isProject) {
         return returnView('project');
     }


### PR DESCRIPTION
## Purpose

Fixes issue reported on Trello: https://trello.com/c/f7fyvCb1

## Changes

Adds a check for a condition where item is pointer but not inside a folder. 

## Side Effects 
None. 