### PR TITLE
Fix issue with trailing comma in contributor names

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -473,14 +473,21 @@ function _poContributors(item) {
     if (!item.data.contributors) {
         return '';
     }
+
     return item.data.contributors.map(function (person, index, arr) {
+        var comma;
+        if(index === 0) {
+            comma = '';
+        } else {
+            comma = ', ';
+        }
         if (index > 2) {
             return;
         }
         if (index === 2) {
             return m('span', ' + ' + (arr.length - 2));
         }
-        return m('span', person.name + ', ');
+        return m('span', comma + person.name );
     });
 }
 


### PR DESCRIPTION
## Purpose 

Fix the trailing comma in the list of contributors 
https://trello.com/c/NKEZdw5g

## Change 
Make the comma addition in front and check if it's the first author in the list

## Side effects
None.  