### PR TITLE
Fix multiple components inside project toolbar view

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -750,6 +750,7 @@ tbOptions = {
     onselectrow : function (item) {
         window.console.log('Row: ', item);
     },
+    filterPlaceholder : "Search",
     onmouseoverrow : _fangornMouseOverRow,
     dropzone : {                                           // All dropzone options.
         url: function(files) {return files[0].url;},

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -722,28 +722,42 @@ function _poMultiselect(event, tree) {
                                   !thisItem.permissions.movable;
             pointerIds.push(thisItem.node_id);
         });
-        if (!someItemsAreFolders) {
-            var multiItemDetailTemplateSource = $('#project-detail-multi-item-template').html(),
+        if(!selectedRows[0].parent().data.isFolder){
+            var multiItemDetailTemplateSource = $('#project-detail-multi-item-no-action').html(),
                 detailTemplate = Handlebars.compile(multiItemDetailTemplateSource),
                 detailTemplateContext = {
-                    multipleItems: true,
                     itemsCount: selectedRows.length
                 },
                 theParentNode = selectedRows[0].parent(),
                 displayHTML = detailTemplate(detailTemplateContext);
             $('.project-details').html(displayHTML);
             $('.project-details').show();
-            $('#remove-links-multiple').click(function () {
-                deleteMultiplePointersFromFolder.call(tb, pointerIds, theParentNode);
-                createBlankProjectDetail();
-            });
-            $('#close-multi-select').click(function () {
-                createBlankProjectDetail();
-                return false;
-            });
         } else {
-            createBlankProjectDetail();
+            if (!someItemsAreFolders) {
+                console.log("some items are folders", someItemsAreFolders);   
+                var multiItemDetailTemplateSource = $('#project-detail-multi-item-template').html(),
+                    detailTemplate = Handlebars.compile(multiItemDetailTemplateSource),
+                    detailTemplateContext = {
+                        multipleItems: true,
+                        itemsCount: selectedRows.length
+                    },
+                    theParentNode = selectedRows[0].parent(),
+                    displayHTML = detailTemplate(detailTemplateContext);
+                $('.project-details').html(displayHTML);
+                $('.project-details').show();
+                $('#remove-links-multiple').click(function () {
+                    deleteMultiplePointersFromFolder.call(tb, pointerIds, theParentNode);
+                    createBlankProjectDetail();
+                });
+                $('#close-multi-select').click(function () {
+                    createBlankProjectDetail();
+                    return false;
+                });
+            } else {
+                createBlankProjectDetail();
+            }
         }
+        
     } else {
         _showProjectDetails.call(tb, event, tb.multiselected[0]);
 

--- a/website/templates/projectGridTemplates.html
+++ b/website/templates/projectGridTemplates.html
@@ -1,91 +1,112 @@
 <script id="project-detail-template" type="text/x-handlebars-template">
     <div class="row" id="ptd-{{ theItem.node_id }}">
-        <div class="col-sm-4">
-            <span class = "title">
-                <span class = "name-container" id="nc-{{theItem.node_id}}">
-                      {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
-                      {{#unless theItem.isFolder}}<a href="{{ theItem.urls.fetch }}">{{{ theItem.name }}}</a>{{#if theItem.isRegistration}} (Registration){{/if}}
-                      {{/unless}}
-                      {{#unless theItem.isDashboard}}{{#unless theItem.isRegistration}}{{#if theItem.permissions.edit}}
-                          <button id="rename-node-{{theItem.node_id}}" class="editableControl dker btn btn-xs">
-                            <i class="icon icon-pencil" style="font-size: 11px;"></i> Edit</button>
-                      {{/if}}{{/unless}}{{/unless}}
+        
+        {{#if theItem.parentIsFolder}}
+            <div class="col-sm-4">
+                <span class = "title">
+                    <span class = "name-container" id="nc-{{theItem.node_id}}">
+                          {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
+                          {{#unless theItem.isFolder}}<a href="{{ theItem.urls.fetch }}">{{{ theItem.name }}}</a>{{#if theItem.isRegistration}} (Registration){{/if}}
+                          {{/unless}}
+                          {{#unless theItem.isDashboard}}{{#unless theItem.isRegistration}}{{#if theItem.permissions.edit}}
+                              <button id="rename-node-{{theItem.node_id}}" class="editableControl dker btn btn-xs">
+                                <i class="icon icon-pencil" style="font-size: 11px;"></i> Edit</button>
+                          {{/if}}{{/unless}}{{/unless}}
+                    </span>
+                    
                 </span>
-                
-            </span>
-        </div>
-        <div class="col-sm-8">
-            <span class="rename-container" id="rnc-{{theItem.node_id}}">
-                    <form action="">
-                          <fieldset class="project-detail-fields">
-                            <div class="row">
-                                <div class="col-xs-8">
-                                    <input class="typeahead" id="rename-node-input{{theItem.node_id}}" type="text" value="{{{theItem.name}}}" autofocus>
-                                </div>
-                                <div class="col-xs-4">
-                                    <input type="submit" class = "rename-node-btn btn btn-sm btn-default submit-button-{{ theItem.node_id }}" id="rename-node-button{{theItem.node_id}}" disabled="disabled" value="Rename">
-                                    <input type="reset" class = "btn btn-sm btn-default cancel-button-{{ theItem.node_id }}" value="Cancel">
-                                </div>                    
-                            </div>
-                          </fieldset>
-                    </form>
-                </span>
-
-            {{#if theItem.isFolder}}
-                <div class = "organize-project-controls pull-right">
-                    <div id = "buttons{{theItem.node_id}}">
-                    <div class = "orgnaize-btn btn btn-sm btn-default" id="add-item-{{theItem.node_id}}">Add Existing Project</div>
-                    <div id="add-folder-{{theItem.node_id}}" class = "orgnaize-btn btn btn-sm btn-default">New Folder</div>
-                        {{#unless theItem.isDashboard}}
-                            <div class = "orgnaize-btn btn btn-sm btn-default" id="delete-folder-{{theItem.node_id}}">Delete Folder</div>
-                        {{/unless}}
-                    </div>
-                    <div id="findNode{{theItem.node_id}}">
+            </div>
+            <div class="col-sm-8">
+                <span class="rename-container" id="rnc-{{theItem.node_id}}">
                         <form action="">
-                        <fieldset class="project-detail-fields">
-                            <div class="row">
-                                <div class="col-xs-8">
-                                    <input class="typeahead" id="input{{theItem.node_id}}" type="text" placeholder="Name of project to find" autofocus>
-                                    <span class="add-link-warning" id="add-link-warn-{{theItem.node_id}}"></span>
+                              <fieldset class="project-detail-fields">
+                                <div class="row">
+                                    <div class="col-xs-8">
+                                        <input class="typeahead" id="rename-node-input{{theItem.node_id}}" type="text" value="{{{theItem.name}}}" autofocus>
+                                    </div>
+                                    <div class="col-xs-4">
+                                        <input type="submit" class = "rename-node-btn btn btn-sm btn-default submit-button-{{ theItem.node_id }}" id="rename-node-button{{theItem.node_id}}" disabled="disabled" value="Rename">
+                                        <input type="reset" class = "btn btn-sm btn-default cancel-button-{{ theItem.node_id }}" value="Cancel">
+                                    </div>                    
                                 </div>
-                                <div class="col-xs-4">
-                                <input type="submit" class = "findBtn btn btn-sm btn-default" id="add-link-{{theItem.node_id}}" disabled="disabled" value="Add">
-                                    <input type="reset" class = "btn btn-sm btn-default cancel-button-{{ theItem.node_id }}" value="Cancel">
-                                </div>
-                            </div>
-                        </fieldset>
-                            </form>
-                    </div>
-                    <div class="add-folder-container" id="afc-{{theItem.node_id}}">
-                        <form action="">
-                        <fieldset class="project-detail-fields">
+                              </fieldset>
+                        </form>
+                    </span>
 
-                        <div class="row">
-                            <div class="col-xs-8">
-                                 <input class = "typeahead" id="add-folder-input{{theItem.node_id}}" type="text" placeholder="Folder Name" autofocus>
-                            </div>
-                            <div class="col-xs-4">
-                                <input type="submit" class = "addFolderBtn btn btn-sm btn-default submit-button-{{ theItem.node_id }}" id="add-folder-button{{theItem.node_id}}" disabled="disabled" value="Add">
-                                <input type="reset" class = "btn btn-sm btn-default cancel-button-{{ theItem.node_id }}" value="Cancel">
-                            </div>
-                        </div>                            
-                        </fieldset>
-                            </form>
-                    </div>
-                </div>
-            {{/if}}
-            {{#unless theItem.isFolder}}
-                {{#if theItem.parentIsFolder}}
-                    {{#unless parentIsSmartFolder}}
-                        <div class = "organize-project-controls pull-right">
-                            <div id = "buttons{{theItem.node_id}}">
-                                <div class="orgnaize-btn btn btn-sm btn-default" id="remove-link-{{theItem.node_id}}">Remove from folder</div>
-                            </div>
+                {{#if theItem.isFolder}}
+                    <div class = "organize-project-controls pull-right">
+                        <div id = "buttons{{theItem.node_id}}">
+                        <div class = "orgnaize-btn btn btn-sm btn-default" id="add-item-{{theItem.node_id}}">Add Existing Project</div>
+                        <div id="add-folder-{{theItem.node_id}}" class = "orgnaize-btn btn btn-sm btn-default">New Folder</div>
+                            {{#unless theItem.isDashboard}}
+                                <div class = "orgnaize-btn btn btn-sm btn-default" id="delete-folder-{{theItem.node_id}}">Delete Folder</div>
+                            {{/unless}}
                         </div>
-                    {{/unless}}
+                        <div id="findNode{{theItem.node_id}}">
+                            <form action="">
+                            <fieldset class="project-detail-fields">
+                                <div class="row">
+                                    <div class="col-xs-8">
+                                        <input class="typeahead" id="input{{theItem.node_id}}" type="text" placeholder="Name of project to find" autofocus>
+                                        <span class="add-link-warning" id="add-link-warn-{{theItem.node_id}}"></span>
+                                    </div>
+                                    <div class="col-xs-4">
+                                    <input type="submit" class = "findBtn btn btn-sm btn-default" id="add-link-{{theItem.node_id}}" disabled="disabled" value="Add">
+                                        <input type="reset" class = "btn btn-sm btn-default cancel-button-{{ theItem.node_id }}" value="Cancel">
+                                    </div>
+                                </div>
+                            </fieldset>
+                                </form>
+                        </div>
+                        <div class="add-folder-container" id="afc-{{theItem.node_id}}">
+                            <form action="">
+                            <fieldset class="project-detail-fields">
+
+                            <div class="row">
+                                <div class="col-xs-8">
+                                     <input class = "typeahead" id="add-folder-input{{theItem.node_id}}" type="text" placeholder="Folder Name" autofocus>
+                                </div>
+                                <div class="col-xs-4">
+                                    <input type="submit" class = "addFolderBtn btn btn-sm btn-default submit-button-{{ theItem.node_id }}" id="add-folder-button{{theItem.node_id}}" disabled="disabled" value="Add">
+                                    <input type="reset" class = "btn btn-sm btn-default cancel-button-{{ theItem.node_id }}" value="Cancel">
+                                </div>
+                            </div>                            
+                            </fieldset>
+                                </form>
+                        </div>
+                    </div>
                 {{/if}}
-            {{/unless}}
-        </div>
+                {{#unless theItem.isFolder}}
+                    {{#if theItem.parentIsFolder}}
+                        {{#unless parentIsSmartFolder}}
+                            <div class = "organize-project-controls pull-right">
+                                <div id = "buttons{{theItem.node_id}}">
+                                    <div class="orgnaize-btn btn btn-sm btn-default" id="remove-link-{{theItem.node_id}}">Remove from folder</div>
+                                </div>
+                            </div>
+                        {{/unless}}
+                    {{/if}}
+                {{/unless}}
+            </div>
+        {{/if}}
+        
+        {{#unless theItem.parentIsFolder}}
+            <div class="col-xs-12">
+                <span class = "title">
+                    <span class = "name-container" id="nc-{{theItem.node_id}}">
+                          {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
+                          {{#unless theItem.isFolder}}<a href="{{ theItem.urls.fetch }}">{{{ theItem.name }}}</a>{{#if theItem.isRegistration}} (Registration){{/if}}
+                          {{/unless}}
+                          {{#unless theItem.isDashboard}}{{#unless theItem.isRegistration}}{{#if theItem.permissions.edit}}
+                              <button id="rename-node-{{theItem.node_id}}" class="editableControl dker btn btn-xs">
+                                <i class="icon icon-pencil" style="font-size: 11px;"></i> Edit</button>
+                          {{/if}}{{/unless}}{{/unless}}
+                    </span>
+                    
+                </span>
+            </div>
+        {{/unless}}
+       
     </div>
 </script>
 
@@ -102,7 +123,20 @@
                 </div>
             </div>
         </div>
-            
-
+    </div>
+</script>
+<script id="project-detail-multi-item-no-action" type="text/x-handlebars-template">
+    <div class="project-detail-box" id="ptd-multi">
+        <div class="row">
+            <div class="col-xs-6">
+                <span class="title">Selection of {{ itemsCount }} items.
+                </span>
+            </div>
+            <div class="col-xs-6">
+                <div class = "project-detail-content pull-right">
+                    <div class="text-muted" style="padding-top: 5px;"><i> No actions </i></div>
+                </div>
+            </div>
+        </div>
     </div>
 </script>


### PR DESCRIPTION
## Purpose

Fixed the trello board issue: https://trello.com/c/YlXqXlNf
Plus expands the title to full toolbar if only title is visible for long titles. 

## Changes 
Added another template for the case of components anf projects inside a project, which have no actions. 

## Side Effects
I checked whether this logic change affects other instances, to my knowledge everything else is working as expected but this would have an impact on the logic where parentfolders would be non folders.   