### PR TITLE
0.24/Fix issue where project organized move did not open folders

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1053,9 +1053,12 @@ function dropLogic(event, items, folder) {
                                 } else {
                                     tb.updateFolder(null, outerFolder);
                                 }
-                            } else {
-                                tb.updateFolder(null, folder);
                             }
+                            // } else {
+                            //     tb.updateFolder(null, folder);
+                            // }
+                            tb.updateFolder(null, folder);
+
                         });
                         postAction.fail(function (jqxhr, textStatus, errorThrown) {
                             $osf.growl('Error:', textStatus + '. ' + errorThrown);


### PR DESCRIPTION
## Purpose

Fixes this issue opened on trello: https://trello.com/c/moxiuUdO

## Changes

There was a logic problem after drop that did not update the folder the item was moved to; hence leading to it not opening. This logic issue is fixed. 

## Side effects

Affects drop events and may influence scenarios when the folder that something is dropped to for some reason should not update itself. 
